### PR TITLE
Support Number group Items and number formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a module for [Magic Mirror²](https://github.com/MichMich/MagicMirror) t
 Supported Items:
  * Rollershutter
  * Switch (does not show the current state of your switch. it will only toggle the switch)
- * Number
+ * Number (and Group:Number)
 
 ![example1.png](https://raw.githubusercontent.com/hggh/MMM-OpenHAB-Items/main/img/example1.png)
 


### PR DESCRIPTION
openHAB items like
Group:Number:AVG gHumidity    "Average Humidity [%.2f %%]" <humidity>
Group:Number:AVG gTemperature "Average Temperature [%.1f °C]" <temperature>

are now supported.

Also the formatting is supported now.

The [%.2f %%] will result in a number with 2 digits after the "." and a "%"
as the unit. For ex: "23.41535364654 %%" -> "23.42 %"

A [%.1f °C] will result in a number with 1 digit after the "." and a "°C"
as the unit. For ex: "23.524235345 °C" -> "23.5 °C"

A ["%d °C"] will result in an integer number and unit "°C". For ex: "5 °C"

Signed-off-by: Stefan Triller <github@stefantriller.de>