### PR TITLE
enable multiple instances with individual configurations

### DIFF
--- a/MMM-OpenHAB-Items.js
+++ b/MMM-OpenHAB-Items.js
@@ -1,6 +1,5 @@
 
 Module.register('MMM-OpenHAB-Items', {
-  items: [],
   config: null,
 
   defaults: {
@@ -13,6 +12,7 @@ Module.register('MMM-OpenHAB-Items', {
   },
 
   start: function() {
+    this.items = [];
     Log.info("Starting module: " + this.name);
     if (this.config.url == null) {
       Log.error("MMM-OpenHAB-Items.js: url parameter in config not found.");
@@ -35,6 +35,7 @@ Module.register('MMM-OpenHAB-Items', {
         this.sendSocketNotification("ITEM_UPDATE_VALUE", {
           url: this.config.url,
           item_name: item.item_name,
+          identifier: this.identifier,
         });
       }
     }
@@ -44,7 +45,7 @@ Module.register('MMM-OpenHAB-Items', {
   },
 
   socketNotificationReceived: function(notification, payload) {
-    if (notification === 'NEW_ITEM') {
+    if (notification === 'NEW_ITEM' && payload.identifier === this.identifier) {
       this.items.push({
         item_label: payload.item_label,
         item_name: payload.item_name,
@@ -54,7 +55,7 @@ Module.register('MMM-OpenHAB-Items', {
         item_only_view: payload.item_only_view,
       })
     }
-    if (notification == 'ITEM_VALUE_UPDATED') {
+    if (notification == 'ITEM_VALUE_UPDATED' && payload.identifier === this.identifier) {
       item_name = payload.item_name;
       item_value = payload.item_value;
       for (var i in this.items) {
@@ -73,6 +74,7 @@ Module.register('MMM-OpenHAB-Items', {
       url: url,
       item_name: item.item_name,
       icon: item.icon,
+      identifier: this.identifier,
     });
   },
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,7 +6,7 @@ var NodeHelper = require("node_helper");
 module.exports = NodeHelper.create({
   socketNotificationReceived: function (notification, payload) {
     if (notification == 'ADD_ITEM') {
-      this.getItem(payload.url, payload.item_name, payload.icon);
+      this.getItem(payload.url, payload.item_name, payload.icon, payload.identifier);
     }
     if (notification == 'TOGGLE_SWITCH') {
       this.toggleSwitch(payload.url, payload.item_name);
@@ -15,11 +15,11 @@ module.exports = NodeHelper.create({
       this.rollershutter(payload.url, payload.item_name, payload.action);
     }
     if (notification == 'ITEM_UPDATE_VALUE') {
-      this.updateItemValue(payload.url, payload.item_name);
+      this.updateItemValue(payload.url, payload.item_name, payload.identifier);
     }
   },
 
-  updateItemValue: function(url, item_name) {
+  updateItemValue: function(url, item_name, identifier) {
     const r = got.get(url + item_name, {responseType: 'json'})
       .then((response) => {
         if (response.body.type.startsWith('Number') || (response.body.type.startsWith('Group') && response.body.groupType.startsWith('Number'))) {
@@ -30,6 +30,7 @@ module.exports = NodeHelper.create({
         this.sendSocketNotification("ITEM_VALUE_UPDATED", {
           item_name: item_name,
           item_value: item_value,
+          identifier: identifier,
         });
       });
   },
@@ -85,11 +86,11 @@ module.exports = NodeHelper.create({
     }
   },
 
-  getItem: function(url, item_name, icon) {
+  getItem: function(url, item_name, icon, identifier) {
     const r = got.get(url + item_name, {responseType: 'json'})
       .then((response) => {
         item_label = response.body.label;
-       
+        
         item_type = null;
         item_value = null;
         item_only_view = false;
@@ -116,6 +117,7 @@ module.exports = NodeHelper.create({
             icon: icon,
             item_value: item_value,
             item_only_view: item_only_view,
+            identifier: identifier,
           });
         }
         else {


### PR DESCRIPTION
Fixes #6 by moving items[] from the prototype to the instance and adding the identifier to filter the notifications.